### PR TITLE
Add DenonRemoteService and refactor serial unit control

### DIFF
--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -26,7 +26,7 @@ namespace Dn500BD
     {
         private Window? _window;
 
-        public static DenonRemoteService RemoteService { get; private set; } = null!;
+        public static IDenonRemoteService RemoteService { get; private set; } = null!;
 
         public App()
         {
@@ -53,7 +53,7 @@ namespace Dn500BD
                 .Create(builder => builder.AddConsole())
                 .CreateLogger("DenonRemote");
 
-            Func<string, ISerialPortService> serialFactory = _ => new SerialPortService();
+            Func<string, ISerialPortService> serialFactory = _ => new SerialPortService(logger);
 
             // Create the global service instance
             RemoteService = new DenonRemoteService(logger, serialFactory);

--- a/Dn500BD.Retrograde.csproj
+++ b/Dn500BD.Retrograde.csproj
@@ -168,6 +168,7 @@
   <!-- Debug|x64 -->
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PlatformTarget>x64</PlatformTarget>
+    <WindowsPackageType>None</WindowsPackageType>
   </PropertyGroup>
 
   <!-- Release|x64 -->

--- a/Retrograde/Core/DenonRemoteController.cs
+++ b/Retrograde/Core/DenonRemoteController.cs
@@ -1,17 +1,16 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using System.Linq;
+using System.Threading;
 using Dn500BD.Retrograde.Infra;
 using Microsoft.Extensions.Logging;
 
 namespace Dn500BD.Retrograde.Core;
 
-public class DenonRemoteController(ISerialPortService serial, ILogger logger) : IDenonRemote
+public class DenonRemoteController : IDenonRemote, IDisposable
 {
-    private readonly ISerialPortService _serial = serial;
-    private readonly ILogger _logger = logger;
+    private readonly ISerialPortService _serial;
+    private readonly ILogger _logger;
 
     private static readonly List<DenonCommand> _defaultCommands =
     [
@@ -20,17 +19,24 @@ public class DenonRemoteController(ISerialPortService serial, ILogger logger) : 
         new DenonCommand("Down", "@0PCCUSR4\r"),
         new DenonCommand("Left", "@0PCCUSR1\r"),
         new DenonCommand("Right", "@0PCCUSR2\r"),
-        new DenonCommand("Enter", "@0PCENTR\r")
+        new DenonCommand("Enter", "@0PCENTR\r"),
+        new DenonCommand("ConnectionTest", "@0?PCCT\r")
     ];
 
-    private readonly Dictionary<string, DenonCommand> _commandMap = _defaultCommands.ToDictionary(cmd => cmd.Label);
+    private readonly Dictionary<string, DenonCommand> _commandMap = _defaultCommands.ToDictionary(c => c.Label);
 
-    public async Task<bool> SendCommandAsync(DenonCommand command)
+    public DenonRemoteController(ISerialPortService serial, ILogger logger)
+    {
+        _serial = serial;
+        _logger = logger;
+    }
+
+    public bool SendCommand(DenonCommand command)
     {
         try
         {
             using var cts = new CancellationTokenSource(3000);
-            bool success = await _serial.SendCommandAsync(command.Code, cts.Token);
+            bool success = _serial.SendCommand(command.Code, cts.Token);
 
             if (success)
                 _logger.LogInformation("Command {Label} sent successfully.", command.Label);
@@ -46,8 +52,26 @@ public class DenonRemoteController(ISerialPortService serial, ILogger logger) : 
         }
     }
 
-    public IEnumerable<DenonCommand> GetAvailableCommands()
+    public bool ValidateConnection(CancellationToken token = default)
     {
-        return _commandMap.Values;
+        try
+        {
+            string response = _serial.SendCommandAndRead(_commandMap["ConnectionTest"].Code, token);
+            _logger.LogInformation("Connection test response: {Response}", response);
+            return response.Contains("PCCT00");
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Connection validation failed");
+            return false;
+        }
+    }
+
+    public IEnumerable<DenonCommand> GetAvailableCommands() => _commandMap.Values;
+
+    public void Dispose()
+    {
+        _logger.LogInformation("Disposing DenonRemoteController and closing serial connection.");
+        _serial.Dispose();
     }
 }

--- a/Retrograde/Core/DenonRemoteService.cs
+++ b/Retrograde/Core/DenonRemoteService.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using Microsoft.Extensions.Logging;
+using Dn500BD.Retrograde.Infra;
+
+namespace Dn500BD.Retrograde.Core;
+
+public class DenonRemoteService
+{
+    private readonly Dictionary<string, UnitController> _controllers = new();
+    private readonly ILogger _logger;
+    private readonly Func<string, ISerialPortService> _serialFactory;
+
+    public DenonRemoteService(ILogger logger, Func<string, ISerialPortService> serialFactory)
+    {
+        _logger = logger;
+        _serialFactory = serialFactory;
+    }
+    public UnitController Connect(string comPort, IEnumerable<Action>? onWindowClosed = null)
+    {
+        if (_controllers.ContainsKey(comPort))
+            throw new InvalidOperationException($"COM port {comPort} is already connected.");
+
+        var serial = _serialFactory(comPort);
+        serial.Open(comPort);
+
+        var remote = new DenonRemoteController(serial, _logger);
+
+        // Validate connection
+        if (!remote.ValidateConnection())
+        {
+            serial.Close();
+            throw new InvalidOperationException($"Device on {comPort} is not a DN-500BD MKII.");
+        }
+
+        var window = new UnitControllerWindow(comPort);
+        var controller = new UnitController(remote, window);
+        _controllers[comPort] = controller;
+
+        window.Closed += (_, _) =>
+        {
+            Disconnect(comPort);
+            if (onWindowClosed != null)
+            {
+                foreach (var callback in onWindowClosed)
+                {
+                    try { callback(); } catch (Exception ex) { _logger.LogWarning(ex, "Callback failed on window close."); }
+                }
+            }
+        };
+
+        window.Activate();
+        window.CenterOnScreen();
+
+        return controller;
+    }
+
+    public void Disconnect(string comPort)
+    {
+        if (_controllers.TryGetValue(comPort, out var controller))
+        {
+            try
+            {
+                controller.Remote?.Dispose();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error disposing remote for {ComPort}", comPort);
+            }
+            _controllers.Remove(comPort);
+        }
+    }
+
+    public UnitController? Get(string comPort)
+    {
+        _controllers.TryGetValue(comPort, out var controller);
+        return controller;
+    }
+
+    public IReadOnlyDictionary<string, UnitController> All => _controllers;
+}

--- a/Retrograde/Core/IDenonRemote.cs
+++ b/Retrograde/Core/IDenonRemote.cs
@@ -1,11 +1,12 @@
 using System.Collections.Generic;
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Dn500BD.Retrograde.Core;
 
 public interface IDenonRemote
 {
-    bool SendCommand(DenonCommand command);
-    bool ValidateConnection(CancellationToken token = default);
+    Task<bool> SendCommandAsync(DenonCommand command, CancellationToken token = default);
+    Task<bool> ValidateConnectionAsync(CancellationToken token = default);
     IEnumerable<DenonCommand> GetAvailableCommands();
 }

--- a/Retrograde/Core/IDenonRemote.cs
+++ b/Retrograde/Core/IDenonRemote.cs
@@ -1,10 +1,11 @@
-﻿using System.Collections.Generic;
-using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Threading;
 
 namespace Dn500BD.Retrograde.Core;
 
 public interface IDenonRemote
 {
-    Task<bool> SendCommandAsync(DenonCommand command);
+    bool SendCommand(DenonCommand command);
+    bool ValidateConnection(CancellationToken token = default);
     IEnumerable<DenonCommand> GetAvailableCommands();
 }

--- a/Retrograde/Core/IDenonRemoteService.cs
+++ b/Retrograde/Core/IDenonRemoteService.cs
@@ -1,0 +1,12 @@
+using System;
+using System.Collections.Generic;
+
+namespace Dn500BD.Retrograde.Core;
+
+public interface IDenonRemoteService
+{
+    UnitController Connect(string comPort, IEnumerable<Action>? onWindowClosed = null);
+    void Disconnect(string comPort);
+    UnitController? Get(string comPort);
+    IReadOnlyDictionary<string, UnitController> All { get; }
+}

--- a/Retrograde/Core/UnitController.cs
+++ b/Retrograde/Core/UnitController.cs
@@ -1,0 +1,14 @@
+
+namespace Dn500BD.Retrograde.Core;
+
+public class UnitController
+{
+    public DenonRemoteController Remote { get; }
+    public UnitControllerWindow Window { get; }
+
+    public UnitController(DenonRemoteController remote, UnitControllerWindow window)
+    {
+        Remote = remote;
+        Window = window;
+    }
+}

--- a/Retrograde/Infra/ISerialPortService.cs
+++ b/Retrograde/Infra/ISerialPortService.cs
@@ -1,5 +1,4 @@
-﻿using System.Threading;
-using System.Threading.Tasks;
+using System.Threading;
 
 namespace Dn500BD.Retrograde.Infra;
 
@@ -8,6 +7,7 @@ public interface ISerialPortService
     bool IsOpen { get; }
     void Open(string portName, int baudRate = 115200);
     void Close();
-    Task<bool> SendCommandAsync(string command, CancellationToken cancellationToken);
+    bool SendCommand(string command, CancellationToken cancellationToken);
+    string SendCommandAndRead(string command, CancellationToken cancellationToken);
     void Dispose();
 }

--- a/Retrograde/Infra/ISerialPortService.cs
+++ b/Retrograde/Infra/ISerialPortService.cs
@@ -1,4 +1,5 @@
 using System.Threading;
+using System.Threading.Tasks;
 
 namespace Dn500BD.Retrograde.Infra;
 
@@ -7,7 +8,7 @@ public interface ISerialPortService
     bool IsOpen { get; }
     void Open(string portName, int baudRate = 115200);
     void Close();
-    bool SendCommand(string command, CancellationToken cancellationToken);
-    string SendCommandAndRead(string command, CancellationToken cancellationToken);
+    Task<bool> SendCommandAsync(string command, CancellationToken cancellationToken);
+    Task<string> SendCommandAndReadAsync(string command, CancellationToken cancellationToken);
     void Dispose();
 }

--- a/Retrograde/Infra/SerialPortService.cs
+++ b/Retrograde/Infra/SerialPortService.cs
@@ -3,112 +3,200 @@ using System.IO;
 using System.IO.Ports;
 using System.Text;
 using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 
 namespace Dn500BD.Retrograde.Infra;
 
 public class SerialPortService : ISerialPortService, IDisposable
 {
+    private readonly ILogger _logger;
     private SerialPort? serialPort;
 
     private const int ResponseTimeoutMs = 300;
+    private readonly object _lock = new();
 
     public bool IsOpen => serialPort != null && serialPort.IsOpen;
 
-    public void Open(string portName, int baudRate = 115200)
+    public SerialPortService(ILogger logger)
     {
-        Close(); // close previous port if needed
+        _logger = logger;
+    }
 
-        serialPort = new SerialPort(portName, baudRate)
+    public void Open(string portName, int baudRate)
+    {
+        lock (_lock)
         {
-            ReadTimeout = ResponseTimeoutMs,
-            WriteTimeout = ResponseTimeoutMs
-        };
+            if (serialPort != null)
+            {
+                try { serialPort.Close(); } catch { }
+                serialPort.Dispose();
+            }
 
-        serialPort.Open();
+            var newSerialPort = new SerialPort(portName, baudRate)
+            {
+                ReadTimeout = ResponseTimeoutMs,
+                WriteTimeout = ResponseTimeoutMs
+            };
+
+            SerialPort? openedPort = null;
+
+            var openTask = Task.Run(() =>
+            {
+                newSerialPort.Open();
+                openedPort = newSerialPort;
+            });
+
+            _logger.LogInformation("Opening port {PortName}...", portName);
+            if (!openTask.Wait(ResponseTimeoutMs))
+            {
+                _logger.LogWarning("Timed out opening port {PortName}", portName);
+                throw new TimeoutException($"Timed out opening serial port {portName} after {ResponseTimeoutMs}ms.");
+            }
+
+            _logger.LogInformation("Successfully opened port {PortName}", portName);
+            serialPort = openedPort!;
+        }
     }
 
     public void Close()
     {
         if (serialPort != null)
         {
-            if (serialPort.IsOpen)
-                serialPort.Close();
+            try
+            {
+                if (serialPort.IsOpen)
+                    serialPort.Close();
+                _logger.LogInformation("Closed port {PortName}", serialPort.PortName);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error closing port");
+            }
 
             serialPort.Dispose();
             serialPort = null;
         }
     }
 
-    public bool SendCommand(string command, CancellationToken cancellationToken)
+    public async Task<bool> SendCommandAsync(string command, CancellationToken cancellationToken)
     {
         if (serialPort == null || !serialPort.IsOpen)
             return false;
 
+        var buffer = Encoding.ASCII.GetBytes(command);
+
         try
         {
-            var buffer = Encoding.ASCII.GetBytes(command);
-            using var reg = cancellationToken.Register(() => serialPort?.DiscardOutBuffer());
-            serialPort.Write(buffer, 0, buffer.Length);
+            await Task.Run(() =>
+            {
+                lock (_lock)
+                {
+                    using var reg = cancellationToken.Register(() => serialPort?.DiscardOutBuffer());
+                    serialPort!.Write(buffer, 0, buffer.Length);
+                }
+            }, cancellationToken);
+
+            _logger.LogInformation("Command sent: {Command}", command);
             return true;
         }
-        catch
+        catch (Exception ex)
         {
+            _logger.LogError(ex, "Failed to send command asynchronously: {Command}", command);
             return false;
         }
     }
 
-    public string SendCommandAndRead(string command, CancellationToken cancellationToken)
+    public async Task<string> SendCommandAndReadAsync(string command, CancellationToken cancellationToken)
     {
-        if (serialPort == null || !serialPort.IsOpen)
-            throw new InvalidOperationException("Serial port is not open.");
+        lock (_lock)
+        {
+            if (serialPort == null || !serialPort.IsOpen)
+                throw new InvalidOperationException("Serial port is not open.");
+
+            serialPort.ReadTimeout = ResponseTimeoutMs;
+            serialPort.WriteTimeout = ResponseTimeoutMs;
+        }
 
         var buffer = Encoding.ASCII.GetBytes(command);
         var response = new StringBuilder();
 
-        using var reg = cancellationToken.Register(() => serialPort?.DiscardInBuffer());
-
         try
         {
-            serialPort.Write(buffer, 0, buffer.Length);
+            _logger.LogInformation("Sending command: {Command}", command);
 
-            var deadline = DateTime.UtcNow + TimeSpan.FromMilliseconds(ResponseTimeoutMs);
-
-            while (DateTime.UtcNow < deadline)
+            await Task.Run(() =>
             {
-                if (cancellationToken.IsCancellationRequested)
-                    throw new TimeoutException("Cancelled while waiting for response.");
-
-                if (serialPort.BytesToRead > 0)
+                lock (_lock)
                 {
-                    int read = serialPort.ReadByte();
-                    if (read == -1) break;
-
-                    char received = (char)read;
-                    if (received == (char)255) break;
-
-                    response.Append(received);
+                    try
+                    {
+                        serialPort!.Write(buffer, 0, buffer.Length);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new IOException($"Write failed on port {serialPort?.PortName}", ex);
+                    }
                 }
-                else
+            }, cancellationToken);
+
+            var readBuffer = new byte[1];
+
+            while (true)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                int bytesRead = await Task.Run(() =>
                 {
-                    Thread.Sleep(10); // poll delay
-                }
+                    try
+                    {
+                        lock (_lock)
+                        {
+                            return serialPort!.BaseStream.Read(readBuffer, 0, 1);
+                        }
+                    }
+                    catch (TimeoutException)
+                    {
+                        return 0;
+                    }
+                }, cancellationToken);
+
+                if (bytesRead == 0)
+                    break;
+
+                char received = (char)readBuffer[0];
+                if (received == (char)255) break;
+
+                response.Append(received);
             }
 
+            _logger.LogInformation("Received response: {Response}", response.ToString());
             return response.ToString();
-        }
-        catch (TimeoutException)
-        {
-            throw;
         }
         catch (Exception ex)
         {
-            throw new IOException("Error during SendCommandAndRead", ex);
+            _logger.LogError(ex, "Error during SendCommandAndReadAsync on {Port}", serialPort?.PortName);
+            throw new IOException($"Error during SendCommandAndReadAsync on {serialPort?.PortName}", ex);
         }
     }
 
     public void Dispose()
     {
-        Close();
+        lock (_lock)
+        {
+            try
+            {
+                serialPort?.DiscardInBuffer();
+                serialPort?.DiscardOutBuffer();
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Error discarding buffers during Dispose");
+            }
+
+            Close();
+        }
+
         GC.SuppressFinalize(this);
     }
 }

--- a/UnitControllerWindow.xaml.cs
+++ b/UnitControllerWindow.xaml.cs
@@ -25,6 +25,7 @@ namespace Dn500BD.Retrograde;
 public sealed partial class UnitControllerWindow : Window
 {
     private readonly string comPort;
+    private bool _initialized = false;
 
     public string PositionLabel { get; } = "00:00";
 
@@ -39,11 +40,24 @@ public sealed partial class UnitControllerWindow : Window
 
         WindowHelpers.ForceDarkTitleBarColors(this);
 
-        Activated += (_, _) =>
+        Activated += OnActivated;
+    }
+    private void OnActivated(object sender, WindowActivatedEventArgs args)
+    {
+        if (_initialized)
+            return;
+
+        _initialized = true;
+
+        try
         {
             WindowHelpers.SetWindowSize(this, 1020, 620);
             WindowHelpers.CenterOnScreen(this);
-        };
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"[Window Init] Failed to set size or center: {ex.Message}");
+        }
     }
 
     public void CenterOnScreen()


### PR DESCRIPTION
## DenonRemoteService marries backend serial i/o functionality with User Interface

* Introduced DenonRemoteService as a central runtime coordinator for COM-port-bound controllers
    * Allows dynamic connection/disconnection of devices
    * Ensures global access to all active units
    * Supports event-driven updates via callbacks

* Refactored MainWindow.xaml.cs to integrate DenonRemoteService
    * Replaced direct SerialPort logic with service calls
    * Added RefreshComPortList with filtering for connected vs. available ports
    * Improved exception handling and error dialogs for connection failures
    * Ensured proper resource cleanup on application exit

* Refactored App.xaml.cs to initialize the DenonRemoteService at startup
    * Injects logger and serial factory
    * Makes service globally accessible via App.RemoteService
    * Registers a global unhandled exception logger for debug output

* Rewrote SerialPortService to use fully synchronous I/O
    * Removed all use of Task and async/await
    * Enforced command timeouts via blocking reads and cancellation tokens
    * Ensured SendCommand returns immediately on error or timeout
    * Implemented precise timeout logic for SendCommandAndRead

* Updated ISerialPortService interface
    * Replaced Task-based method signatures with synchronous equivalents
    * Method names: SendCommand(string, CancellationToken), SendCommandAndRead(string, CancellationToken)

* Updated DenonRemoteController to support new serial interface
    * Replaced async logic with synchronous calls and structured error handling
    * Implemented ValidateConnection using the `@0?PCCT` command-response pattern
    * Added disposal behavior for serial connections

* Updated IDenonRemote interface
    * Replaced Task-based SendCommandAsync with bool SendCommand
    * Added ValidateConnection(CancellationToken) method

* Added new Core components:
    * DenonRemoteService.cs – global runtime orchestration for serial units
    * UnitController.cs – placeholder for unit-level orchestration logic

* Updated UnitControllerWindow.xaml.cs
    * Ensured activation logic runs only once using `_initialized` guard
    * Moved window sizing and centering into a safer activation block

* Minor project cleanup
    * Set <WindowsPackageType>None in .csproj to avoid packaging warnings
    * Removed unused using directives across multiple files